### PR TITLE
Add Dockerfile and connector Helm chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Dockerfile for building MinimumViableDataspace connector images
+FROM eclipse-temurin:17-jdk-alpine as builder
+
+# Install git, bash, and other required tools
+RUN apk add --no-cache git bash
+
+WORKDIR /opt
+
+# Clone the MVD repository
+RUN git clone https://github.com/eclipse-edc/MinimumViableDataspace.git mvd
+
+WORKDIR /opt/mvd
+
+# Build the runtime images using gradle as described in the README
+RUN ./gradlew build && \
+    ./gradlew -Ppersistence=true dockerize
+
+# Use a minimal base image that only contains the resulting images
+FROM scratch as artifacts
+COPY --from=builder /opt/mvd .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # Eclipse EDC - Connector
+
+This repository contains helper resources to build the [Minimum Viable Dataspace](https://github.com/eclipse-edc/MinimumViableDataspace) (MVD) images and a Helm chart for deploying an EDC connector.
+
+## Dockerfile
+
+The provided `Dockerfile` clones the MVD repository and builds the runtime images using the Gradle tasks documented in the MVD project. After building, the Docker cache contains the images `controlplane:latest`, `dataplane:latest`, `catalog-server:latest` and `identity-hub:latest`.
+
+Build the images with:
+
+```bash
+docker build -t mvd-builder .
+```
+
+The resulting container image `mvd-builder` only contains the repository with the built images in its Docker cache.
+
+## Helm chart
+
+Under `charts/connector` a basic Helm chart is provided. It deploys a control plane and a data plane using the images built from the Dockerfile. Default values can be adjusted in `values.yaml`.
+
+Install the chart into a Kubernetes cluster with:
+
+```bash
+helm install my-connector charts/connector
+```
+
+The chart exposes services and an ingress similar to the Terraform deployment supplied by the MVD project.

--- a/charts/connector/Chart.yaml
+++ b/charts/connector/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: connector
+version: 0.1.0
+appVersion: "1.0"
+description: Helm chart for Eclipse EDC Minimum Viable Dataspace Connector

--- a/charts/connector/templates/_helpers.tpl
+++ b/charts/connector/templates/_helpers.tpl
@@ -1,0 +1,8 @@
+{{- define "connector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "connector.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/connector/templates/controlplane-configmap.yaml
+++ b/charts/connector/templates/controlplane-configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "connector.fullname" . }}-controlplane-config
+  namespace: {{ .Values.namespace }}
+data:
+  EDC_PARTICIPANT_ID: {{ .Values.participantId | quote }}
+  EDC_IAM_ISSUER_ID: {{ .Values.participantId | quote }}
+  EDC_IAM_DID_WEB_USE_HTTPS: "false"
+  WEB_HTTP_PORT: "{{ .Values.controlplane.ports.web }}"
+  WEB_HTTP_PATH: "/api"
+  WEB_HTTP_MANAGEMENT_PORT: "{{ .Values.controlplane.ports.management }}"
+  WEB_HTTP_MANAGEMENT_PATH: "/api/management"
+  WEB_HTTP_MANAGEMENT_AUTH_TYPE: "tokenbased"
+  WEB_HTTP_MANAGEMENT_AUTH_KEY: "password"
+  WEB_HTTP_CONTROL_PORT: "{{ .Values.controlplane.ports.control }}"
+  WEB_HTTP_CONTROL_PATH: "/api/control"
+  WEB_HTTP_PROTOCOL_PORT: "{{ .Values.controlplane.ports.protocol }}"
+  WEB_HTTP_PROTOCOL_PATH: "/api/dsp"
+  WEB_HTTP_CATALOG_PORT: "{{ .Values.controlplane.ports.catalog }}"
+  WEB_HTTP_CATALOG_PATH: "/api/catalog"
+  WEB_HTTP_CATALOG_AUTH_TYPE: "tokenbased"
+  WEB_HTTP_CATALOG_AUTH_KEY: "password"
+  EDC_DSP_CALLBACK_ADDRESS: "http://{{ include "connector.fullname" . }}-controlplane:{{ .Values.controlplane.ports.protocol }}/api/dsp"
+  EDC_VAULT_HASHICORP_URL: {{ .Values.vault.url | quote }}
+  EDC_VAULT_HASHICORP_TOKEN: {{ .Values.vault.token | quote }}
+  EDC_MVD_PARTICIPANTS_LIST_FILE: "/etc/participants/participants.json"
+  EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS: "10"
+  EDC_CATALOG_CACHE_EXECUTION_PERIOD_SECONDS: "10"
+  EDC_DATASOURCE_DEFAULT_URL: {{ .Values.jdbc.url | quote }}
+  EDC_DATASOURCE_DEFAULT_USER: {{ .Values.jdbc.user | quote }}
+  EDC_DATASOURCE_DEFAULT_PASSWORD: {{ .Values.jdbc.password | quote }}
+  EDC_SQL_SCHEMA_AUTOCREATE: "true"
+  EDC_IAM_STS_OAUTH_TOKEN_URL: {{ .Values.stsTokenUrl | quote }}
+  EDC_IAM_STS_OAUTH_CLIENT_ID: {{ .Values.participantId | quote }}
+  EDC_IAM_STS_OAUTH_CLIENT_SECRET_ALIAS: "{{ .Values.participantId }}-sts-client-secret"
+  JAVA_TOOL_OPTIONS: "{{ ternary "-XX:UseSVE=0" "" .Values.useSVE }}-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={{ .Values.controlplane.ports.debug }}"

--- a/charts/connector/templates/controlplane-deployment.yaml
+++ b/charts/connector/templates/controlplane-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "connector.fullname" . }}-controlplane
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ include "connector.fullname" . }}-controlplane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "connector.fullname" . }}-controlplane
+  template:
+    metadata:
+      labels:
+        app: {{ include "connector.fullname" . }}-controlplane
+    spec:
+      containers:
+        - name: connector
+          image: "{{ .Values.controlplane.image.repository }}:{{ .Values.controlplane.image.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "connector.fullname" . }}-controlplane-config
+          volumeMounts:
+            - name: participants-volume
+              mountPath: /etc/participants
+          ports:
+            - containerPort: {{ .Values.controlplane.ports.management }}
+              name: management-port
+            - containerPort: {{ .Values.controlplane.ports.web }}
+              name: default-port
+            - containerPort: {{ .Values.controlplane.ports.debug }}
+              name: debug-port
+      volumes:
+        - name: participants-volume
+          configMap:
+            name: {{ include "connector.fullname" . }}-participants

--- a/charts/connector/templates/controlplane-service.yaml
+++ b/charts/connector/templates/controlplane-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "connector.fullname" . }}-controlplane
+  namespace: {{ .Values.namespace }}
+spec:
+  type: NodePort
+  selector:
+    app: {{ include "connector.fullname" . }}-controlplane
+  ports:
+    - name: health
+      port: {{ .Values.controlplane.ports.web }}
+    - name: management
+      port: {{ .Values.controlplane.ports.management }}
+    - name: catalog
+      port: {{ .Values.controlplane.ports.catalog }}
+    - name: protocol
+      port: {{ .Values.controlplane.ports.protocol }}
+    - name: debug
+      port: {{ .Values.controlplane.ports.debug }}
+    - name: control
+      port: {{ .Values.controlplane.ports.control }}

--- a/charts/connector/templates/dataplane-configmap.yaml
+++ b/charts/connector/templates/dataplane-configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "connector.fullname" . }}-dataplane-config
+  namespace: {{ .Values.namespace }}
+data:
+  EDC_HOSTNAME: {{ include "connector.fullname" . }}-dataplane
+  EDC_RUNTIME_ID: {{ include "connector.fullname" . }}-dataplane
+  EDC_PARTICIPANT_ID: {{ .Values.participantId | quote }}
+  EDC_TRANSFER_PROXY_TOKEN_VERIFIER_PUBLICKEY_ALIAS: "{{ .Values.participantId }}#key-1"
+  EDC_TRANSFER_PROXY_TOKEN_SIGNER_PRIVATEKEY_ALIAS: "{{ .Values.participantId }}#key-1"
+  EDC_DPF_SELECTOR_URL: "http://{{ include "connector.fullname" . }}-controlplane:{{ .Values.controlplane.ports.control }}/api/control/v1/dataplanes"
+  WEB_HTTP_PORT: "{{ .Values.dataplane.ports.web }}"
+  WEB_HTTP_PATH: "/api"
+  WEB_HTTP_CONTROL_PORT: "{{ .Values.dataplane.ports.control }}"
+  WEB_HTTP_CONTROL_PATH: "/api/control"
+  WEB_HTTP_PUBLIC_PORT: "{{ .Values.dataplane.ports.public }}"
+  WEB_HTTP_PUBLIC_PATH: "/api/public"
+  EDC_VAULT_HASHICORP_URL: {{ .Values.vault.url | quote }}
+  EDC_VAULT_HASHICORP_TOKEN: {{ .Values.vault.token | quote }}
+  JAVA_TOOL_OPTIONS: "{{ ternary "-XX:UseSVE=0" "" .Values.useSVE }}-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={{ .Values.dataplane.ports.debug }}"
+  EDC_DATASOURCE_DEFAULT_URL: {{ .Values.jdbc.url | quote }}
+  EDC_DATASOURCE_DEFAULT_USER: {{ .Values.jdbc.user | quote }}
+  EDC_DATASOURCE_DEFAULT_PASSWORD: {{ .Values.jdbc.password | quote }}
+  EDC_SQL_SCHEMA_AUTOCREATE: "true"
+  EDC_IAM_STS_OAUTH_TOKEN_URL: {{ .Values.stsTokenUrl | quote }}
+  EDC_IAM_STS_OAUTH_CLIENT_ID: {{ .Values.participantId | quote }}
+  EDC_IAM_STS_OAUTH_CLIENT_SECRET_ALIAS: "{{ .Values.participantId }}-sts-client-secret"

--- a/charts/connector/templates/dataplane-deployment.yaml
+++ b/charts/connector/templates/dataplane-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "connector.fullname" . }}-dataplane
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ include "connector.fullname" . }}-dataplane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "connector.fullname" . }}-dataplane
+  template:
+    metadata:
+      labels:
+        app: {{ include "connector.fullname" . }}-dataplane
+    spec:
+      containers:
+        - name: dataplane
+          image: "{{ .Values.dataplane.image.repository }}:{{ .Values.dataplane.image.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "connector.fullname" . }}-dataplane-config
+          ports:
+            - containerPort: {{ .Values.dataplane.ports.public }}
+              name: public-port
+            - containerPort: {{ .Values.dataplane.ports.debug }}
+              name: debug-port

--- a/charts/connector/templates/dataplane-service.yaml
+++ b/charts/connector/templates/dataplane-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "connector.fullname" . }}-dataplane
+  namespace: {{ .Values.namespace }}
+spec:
+  type: NodePort
+  selector:
+    app: {{ include "connector.fullname" . }}-dataplane
+  ports:
+    - name: control
+      port: {{ .Values.dataplane.ports.control }}
+    - name: public
+      port: {{ .Values.dataplane.ports.public }}

--- a/charts/connector/templates/ingress.yaml
+++ b/charts/connector/templates/ingress.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "connector.fullname" . }}-ingress
+  namespace: {{ .Values.namespace }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: "/{{ include "connector.fullname" . }}/health(/|$)(.*)"
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "connector.fullname" . }}-controlplane
+                port:
+                  number: {{ .Values.controlplane.ports.web }}
+          - path: "/{{ include "connector.fullname" . }}/cp(/|$)(.*)"
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "connector.fullname" . }}-controlplane
+                port:
+                  number: {{ .Values.controlplane.ports.management }}
+          - path: "/{{ include "connector.fullname" . }}/public(/|$)(.*)"
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "connector.fullname" . }}-dataplane
+                port:
+                  number: {{ .Values.dataplane.ports.public }}
+          - path: "/{{ include "connector.fullname" . }}/fc(/|$)(.*)"
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "connector.fullname" . }}-controlplane
+                port:
+                  number: {{ .Values.controlplane.ports.catalog }}

--- a/charts/connector/templates/participants-configmap.yaml
+++ b/charts/connector/templates/participants-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "connector.fullname" . }}-participants
+  namespace: {{ .Values.namespace }}
+data:
+  participants.json: |
+{{ toJson .Values.participantsList | indent 4 }}

--- a/charts/connector/values.yaml
+++ b/charts/connector/values.yaml
@@ -1,0 +1,37 @@
+imagePullPolicy: IfNotPresent
+controlplane:
+  image:
+    repository: controlplane
+    tag: latest
+  ports:
+    web: 8080
+    management: 8081
+    protocol: 8082
+    control: 8083
+    catalog: 8084
+    debug: 1044
+
+dataplane:
+  image:
+    repository: dataplane
+    tag: latest
+  ports:
+    web: 8080
+    control: 8083
+    public: 11002
+    debug: 1055
+
+participantId: "did:web:participant"
+namespace: default
+vault:
+  url: http://vault:8200
+  token: root
+stsTokenUrl: http://sts/token
+jdbc:
+  url: jdbc:postgresql://postgres:5432/edc
+  user: edc
+  password: edc
+participantsList:
+  consumer-corp: "did:web:consumer"
+  provider-corp: "did:web:provider"
+useSVE: false


### PR DESCRIPTION
## Summary
- add Dockerfile that clones the MinimumViableDataspace repo and builds the images
- create Helm chart for deploying controlplane and dataplane
- update README with build and usage instructions

## Testing
- `helm lint charts/connector` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840af416700832590b00c6e40693cad